### PR TITLE
docs: add Quick Start section with npm installation and AI instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,78 @@ An MCP (Model Context Protocol) server for the Skylight Calendar API. Enables AI
 - **Family**: View family members and devices
 - **Rewards**: Check reward points and available rewards
 
+## Quick Start
+
+### Installation
+
+#### Option 1: npm package (Recommended)
+
+**mcp.json:**
+```json
+{
+  "mcpServers": {
+    "skylight": {
+      "command": "npx",
+      "args": ["@eaglebyte/skylight-mcp"],
+      "env": {
+        "SKYLIGHT_EMAIL": "your_email@example.com",
+        "SKYLIGHT_PASSWORD": "your_password",
+        "SKYLIGHT_FRAME_ID": "your_frame_id"
+      }
+    }
+  }
+}
+```
+
+**Claude Code:**
+```bash
+claude mcp add skylight npx @eaglebyte/skylight-mcp \
+  -e SKYLIGHT_EMAIL=your_email@example.com \
+  -e SKYLIGHT_PASSWORD=your_password \
+  -e SKYLIGHT_FRAME_ID=your_frame_id
+```
+
+#### Option 2: From source
+
+```bash
+git clone https://github.com/TheEagleByte/skylight-mcp.git
+cd skylight-mcp && npm install && npm run build
+```
+
+Then use in mcp.json:
+```json
+{
+  "mcpServers": {
+    "skylight": {
+      "command": "node",
+      "args": ["/path/to/skylight-mcp/dist/index.js"],
+      "env": {
+        "SKYLIGHT_EMAIL": "your_email@example.com",
+        "SKYLIGHT_PASSWORD": "your_password",
+        "SKYLIGHT_FRAME_ID": "your_frame_id"
+      }
+    }
+  }
+}
+```
+
+### Instructions for AI
+
+Copy this into your AI's custom instructions or system prompt:
+
+> You have access to the Skylight MCP server. Skylight is a smart family calendar display that shows calendars, chores, grocery lists, meals, and rewards. Use the Skylight tools to help manage family schedules and organization.
+>
+> Tips:
+> - Call `get_family_members` before assigning chores to get member names
+> - Grocery items default to the main grocery list if no list specified
+> - Dates accept "today", "tomorrow", day names, or YYYY-MM-DD format
+> - Some tools (rewards, meals, photos) require Skylight Plus subscription
+
 ## Prerequisites
 
 - Node.js 18+
 - A Skylight account with an active subscription
-- Your Skylight API token (see [Authentication](#authentication))
-
-## Installation
-
-```bash
-git clone https://github.com/TheEagleByte/skylight-mcp.git
-cd skylight-mcp
-npm install
-npm run build
-```
+- Your Skylight Frame ID (see [Finding your Frame ID](#finding-your-frame-id))
 
 ## Authentication
 
@@ -78,26 +136,6 @@ SKYLIGHT_EMAIL=your_email@example.com
 SKYLIGHT_PASSWORD=your_password
 SKYLIGHT_FRAME_ID=your_frame_id
 SKYLIGHT_TIMEZONE=America/New_York
-```
-
-## Usage with Claude Desktop
-
-Add to your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
-
-```json
-{
-  "mcpServers": {
-    "skylight": {
-      "command": "node",
-      "args": ["/path/to/skylight-mcp/dist/index.js"],
-      "env": {
-        "SKYLIGHT_EMAIL": "your_email@example.com",
-        "SKYLIGHT_PASSWORD": "your_password",
-        "SKYLIGHT_FRAME_ID": "your_frame_id"
-      }
-    }
-  }
-}
 ```
 
 ## Available Tools
@@ -171,16 +209,6 @@ npm test
 # Type check
 npm run typecheck
 ```
-
-## Known Limitations
-
-The following features are not yet available in the reverse-engineered API:
-
-- Creating calendar events
-- Adding items to lists
-- Meal plans
-
-These limitations are due to the endpoints not being documented in the community API reference.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,17 @@
 {
-  "name": "@skylight/mcp-server",
-  "version": "1.0.0",
+  "name": "@eaglebyte/skylight-mcp",
+  "version": "1.1.0",
   "description": "MCP server for Skylight Calendar API - enables agentic interactions for calendar, chores, lists, and family management",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
     "skylight-mcp": "dist/index.js"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "scripts": {
     "build": "tsc",
     "start": "node dist/index.js",


### PR DESCRIPTION
## Summary
- Add Quick Start section at top of README with npm package and source installation options
- Add copy-pasteable AI instructions snippet for system prompts
- Update package name to `@eaglebyte/skylight-mcp` and bump to v1.1.0
- Remove outdated sections (Known Limitations, redundant Claude Desktop usage)

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Test `npx @eaglebyte/skylight-mcp` after publishing
- [ ] Copy AI instructions to Claude and verify it understands Skylight context

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded Quick Start guide with multiple installation options (npm package and from source).
  * Added comprehensive Configuration section with environment variables table.
  * Enhanced authentication documentation with email/password and token-based methods.
  * Added Frame ID lookup instructions.

* **Chores**
  * Updated package name and version.
  * Configured distribution files in manifest.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->