### PR TITLE
Fix authentication format and calendar date handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.7] - 2025-12-30
+
+### Fixed
+
+- **Authentication**: Fixed email/password authentication to use correct `Basic base64(userId:token)` format instead of `Bearer token`. The Skylight API requires the user ID and token to be combined and base64-encoded for Basic auth.
+- **Calendar Events**: Fixed `get_calendar_events` returning no events when querying a single day. The API treats `date_max` as exclusive, so we now add 1 day to ensure events on the end date are included.
+
+### Changed
+
+- Added debug logging for authentication flow to help troubleshoot login issues
+- Added automatic retry on 401 errors for email/password auth (attempts re-login once before failing)
+
+## [1.1.6] - 2025-12-29
+
+- Initial public release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eaglebyte/skylight-mcp",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "MCP server for Skylight Calendar API - enables agentic interactions for calendar, chores, lists, and family management",
   "type": "module",
   "main": "dist/index.js",

--- a/src/api/endpoints/calendar.ts
+++ b/src/api/endpoints/calendar.ts
@@ -17,17 +17,31 @@ export interface GetCalendarEventsOptions {
 }
 
 /**
+ * Add days to a date string in YYYY-MM-DD format
+ */
+function addDays(dateStr: string, days: number): string {
+  const date = new Date(dateStr + "T00:00:00");
+  date.setDate(date.getDate() + days);
+  return date.toISOString().split("T")[0];
+}
+
+/**
  * Get calendar events for a date range
+ * Note: The API treats date_max as exclusive, so we add 1 day to include events on the end date
  */
 export async function getCalendarEvents(
   options: GetCalendarEventsOptions
 ): Promise<CalendarEventResource[]> {
   const client = getClient();
+
+  // API treats date_max as exclusive, so add 1 day to include events on the end date
+  const adjustedDateMax = addDays(options.dateMax, 1);
+
   const response = await client.get<CalendarEventsResponse>(
     "/api/frames/{frameId}/calendar_events",
     {
       date_min: options.dateMin,
-      date_max: options.dateMax,
+      date_max: adjustedDateMax,
       timezone: options.timezone ?? client.timezone,
       include: options.include,
     }


### PR DESCRIPTION
## Summary

- **Fix email/password authentication**: Changed from `Bearer token` to `Basic base64(userId:token)` format, which is what the Skylight API actually expects
- **Fix calendar events query**: The API treats `date_max` as exclusive, so querying a single day (e.g., `2025-12-30` to `2025-12-30`) returned no events. Now we add 1 day to `date_max` to include events on the end date
- **Add debug logging**: Added logging for auth flow to help troubleshoot login issues
- **Add automatic retry**: For email/password auth, automatically retry once on 401 errors by re-logging in

## Test plan

- [x] Verify email/password login works correctly
- [x] Verify `get_calendar_events` returns events for a single day
- [x] Verify calendar events for date ranges work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed calendar event retrieval to correctly include the end date in results
  * Added automatic retry on temporary authentication failures to reduce manual re-login requirements

* **Changes**
  * Updated authentication protocol to use improved security methods
  * Enhanced error messaging for better troubleshooting of authentication issues

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->