### PR TITLE
Fix list item creation/update - use simple JSON format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@skylight/mcp-server",
-  "version": "1.1.6",
+  "name": "@eaglebyte/skylight-mcp",
+  "version": "1.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@skylight/mcp-server",
-      "version": "1.1.6",
+      "name": "@eaglebyte/skylight-mcp",
+      "version": "1.1.7",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.11.0",

--- a/src/api/endpoints/lists.ts
+++ b/src/api/endpoints/lists.ts
@@ -7,7 +7,6 @@ import type {
   CreateListRequest,
   UpdateListRequest,
   CreateListItemRequest,
-  UpdateListItemRequest,
   ListItemResponse,
 } from "../types.js";
 
@@ -121,6 +120,7 @@ export async function deleteList(listId: string): Promise<void> {
 
 /**
  * Create a new list item
+ * Note: This endpoint uses simple JSON format, not JSON:API like other endpoints
  */
 export async function createListItem(
   listId: string,
@@ -129,13 +129,8 @@ export async function createListItem(
 ): Promise<ListItemResource> {
   const client = getClient();
   const request: CreateListItemRequest = {
-    data: {
-      type: "list_item",
-      attributes: {
-        label,
-        section: section ?? null,
-      },
-    },
+    label,
+    section: section ?? null,
   };
   const response = await client.post<ListItemResponse>(
     `/api/frames/{frameId}/lists/${listId}/list_items`,
@@ -146,6 +141,7 @@ export async function createListItem(
 
 /**
  * Update a list item
+ * Note: This endpoint uses simple JSON format, not JSON:API like other endpoints
  */
 export async function updateListItem(
   listId: string,
@@ -153,15 +149,9 @@ export async function updateListItem(
   updates: { label?: string; status?: "pending" | "completed"; section?: string | null }
 ): Promise<ListItemResource> {
   const client = getClient();
-  const request: UpdateListItemRequest = {
-    data: {
-      type: "list_item",
-      attributes: updates,
-    },
-  };
   const response = await client.request<ListItemResponse>(
     `/api/frames/{frameId}/lists/${listId}/list_items/${itemId}`,
-    { method: "PUT", body: request }
+    { method: "PUT", body: updates }
   );
   return response.data;
 }

--- a/src/api/endpoints/lists.ts
+++ b/src/api/endpoints/lists.ts
@@ -7,6 +7,7 @@ import type {
   CreateListRequest,
   UpdateListRequest,
   CreateListItemRequest,
+  UpdateListItemRequest,
   ListItemResponse,
 } from "../types.js";
 
@@ -146,7 +147,7 @@ export async function createListItem(
 export async function updateListItem(
   listId: string,
   itemId: string,
-  updates: { label?: string; status?: "pending" | "completed"; section?: string | null }
+  updates: UpdateListItemRequest
 ): Promise<ListItemResource> {
   const client = getClient();
   const response = await client.request<ListItemResponse>(

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -229,26 +229,17 @@ export interface UpdateListRequest {
 }
 
 // List item request types
+// Note: Unlike other endpoints, list item create/update use simple JSON format, not JSON:API
 export interface CreateListItemRequest {
-  data: {
-    type: "list_item";
-    attributes: {
-      label: string;
-      section?: string | null;
-    };
-  };
+  label: string;
+  section?: string | null;
 }
 
 export interface UpdateListItemRequest {
-  data: {
-    type: "list_item";
-    attributes: Partial<{
-      label: string;
-      status: "pending" | "completed";
-      section: string | null;
-      position: number | null;
-    }>;
-  };
+  label?: string;
+  status?: "pending" | "completed";
+  section?: string | null;
+  position?: number | null;
 }
 
 export type ListItemResponse = JsonApiResponse<ListItemResource>;


### PR DESCRIPTION
Fixes #29

## Problem
The `create_list_item` and `update_list_item` tools fail with "Label can't be blank" error because they use JSON:API format while the Skylight API expects simple JSON for these specific endpoints.

## Solution
- Updated `CreateListItemRequest` and `UpdateListItemRequest` types to use simple format
- Modified `createListItem()` to send `{label, section}` directly  
- Modified `updateListItem()` to send updates directly
- Added comments noting the format difference

## Testing
✅ Built successfully with TypeScript
✅ Tested with live Skylight API - items now create correctly  
✅ Other endpoints (calendar, chores) still work as expected

## API Format
**Before (broken):**
```json
{"data": {"type": "list_item", "attributes": {"label": "Diet Coke"}}}
```

**After (working):**
```json
{"label": "Diet Coke"}
```

Verified via Chrome DevTools that this matches the actual API behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified create/update list-item payloads to a flat JSON structure (removed nesting).
  * Update endpoint now accepts direct partial updates (label, status, section, position) in the request body.
  * Both create and update list-item endpoints use plain JSON instead of JSON:API wrapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->