### PR TITLE
Fix auth: migrate to OAuth refresh flow with token persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ An MCP (Model Context Protocol) server for the Skylight Calendar API. Enables AI
       "command": "npx",
       "args": ["@eaglebyte/skylight-mcp"],
       "env": {
-        "SKYLIGHT_EMAIL": "your_email@example.com",
-        "SKYLIGHT_PASSWORD": "your_password",
+        "SKYLIGHT_ACCESS_TOKEN": "your_access_token",
+        "SKYLIGHT_REFRESH_TOKEN": "your_refresh_token",
+        "SKYLIGHT_DEVICE_FINGERPRINT": "your_device_fingerprint",
         "SKYLIGHT_FRAME_ID": "your_frame_id"
       }
     }
@@ -37,8 +38,9 @@ An MCP (Model Context Protocol) server for the Skylight Calendar API. Enables AI
 **Claude Code:**
 ```bash
 claude mcp add skylight npx @eaglebyte/skylight-mcp \
-  -e SKYLIGHT_EMAIL=your_email@example.com \
-  -e SKYLIGHT_PASSWORD=your_password \
+  -e SKYLIGHT_ACCESS_TOKEN=your_access_token \
+  -e SKYLIGHT_REFRESH_TOKEN=your_refresh_token \
+  -e SKYLIGHT_DEVICE_FINGERPRINT=your_device_fingerprint \
   -e SKYLIGHT_FRAME_ID=your_frame_id
 ```
 
@@ -57,8 +59,9 @@ Then use in mcp.json:
       "command": "node",
       "args": ["/path/to/skylight-mcp/dist/index.js"],
       "env": {
-        "SKYLIGHT_EMAIL": "your_email@example.com",
-        "SKYLIGHT_PASSWORD": "your_password",
+        "SKYLIGHT_ACCESS_TOKEN": "your_access_token",
+        "SKYLIGHT_REFRESH_TOKEN": "your_refresh_token",
+        "SKYLIGHT_DEVICE_FINGERPRINT": "your_device_fingerprint",
         "SKYLIGHT_FRAME_ID": "your_frame_id"
       }
     }
@@ -86,27 +89,65 @@ Copy this into your AI's custom instructions or system prompt:
 
 ## Authentication
 
-The MCP server supports two authentication methods:
+Skylight migrated their API to OAuth 2.0. The previous `SKYLIGHT_EMAIL` / `SKYLIGHT_PASSWORD` endpoint (`POST /api/sessions`) now returns HTTP 401 "This version of Skylight is no longer supported" and is no longer functional. Two authentication modes are supported:
 
-### Option 1: Email/Password (Recommended)
+### Option 1: OAuth refresh token (Recommended)
 
-Use your Skylight account credentials. The server will automatically log in and manage tokens.
+Capture an access token, refresh token, and device fingerprint from the Skylight web app once. The server uses the refresh token to mint new access tokens automatically as they expire, and persists rotated tokens to disk so cold starts continue from the latest pair.
 
 ```env
-SKYLIGHT_EMAIL=your_email@example.com
-SKYLIGHT_PASSWORD=your_password
+SKYLIGHT_ACCESS_TOKEN=your_access_token
+SKYLIGHT_REFRESH_TOKEN=your_refresh_token
+SKYLIGHT_DEVICE_FINGERPRINT=your_device_fingerprint
 SKYLIGHT_FRAME_ID=your_frame_id
 ```
 
-### Option 2: Manual Token (Legacy)
+**One-time capture procedure:**
 
-Capture a token from the Skylight app using a proxy tool.
+1. Open Chrome or Edge, then open DevTools (F12) and switch to the **Network** tab.
+2. Enable **Preserve log** so requests survive the post-login redirect.
+3. Browse to `https://app.ourskylight.com` and log in with your Skylight account.
+4. In the Network tab filter, type `oauth/token`. Find the **POST** that returned `200`.
+5. Copy three values from that request:
+   - **Response** tab → `access_token` → `SKYLIGHT_ACCESS_TOKEN`
+   - **Response** tab → `refresh_token` → `SKYLIGHT_REFRESH_TOKEN`
+   - **Payload** tab (Form Data) → `skylight_api_client_device_fingerprint` → `SKYLIGHT_DEVICE_FINGERPRINT`
+
+You only do this once. After the first run the persistence layer (see [Token Persistence](#token-persistence) below) handles rotation transparently. Re-capture is only needed if the refresh token is invalidated by long inactivity, or if you delete the state file.
+
+### Option 2: Manual bearer token
+
+For users who prefer to manage tokens manually, supply a single bearer token. No automatic refresh; the token expires when Skylight expires it.
 
 ```env
 SKYLIGHT_TOKEN=your_token_here
-SKYLIGHT_FRAME_ID=your_frame_id
 SKYLIGHT_AUTH_TYPE=bearer
+SKYLIGHT_FRAME_ID=your_frame_id
 ```
+
+`SKYLIGHT_AUTH_TYPE` accepts `bearer` (default) or `basic`.
+
+### Token Persistence
+
+When using OAuth refresh-token mode (`SKYLIGHT_ACCESS_TOKEN` / `SKYLIGHT_REFRESH_TOKEN` / `SKYLIGHT_DEVICE_FINGERPRINT`), Skylight rotates the refresh token on every refresh — the old refresh token is invalidated the moment a new one is issued. To survive process restarts, the server persists the rotated tokens to a state file on disk:
+
+- **Windows:** `%APPDATA%\skylight-mcp\state.json`
+- **macOS:** `~/Library/Application Support/skylight-mcp/state.json`
+- **Linux:** `$XDG_DATA_HOME/skylight-mcp/state.json` (default `~/.local/share/skylight-mcp/state.json`)
+
+On startup the server reads tokens from the state file first; the env-var values only **seed** the very first run (or any run after the state file is deleted). You only need to re-capture tokens when:
+
+- The refresh token expires due to long inactivity.
+- You delete the state file.
+- The state file becomes corrupt (the server logs a warning and falls back to env vars).
+
+To inspect the current state file (token prefixes only, no full secrets are printed):
+
+```bash
+node scripts/show-state.mjs
+```
+
+The state path can be overridden with the `SKYLIGHT_STATE_FILE` env var, which is useful for tests or running multiple isolated configurations side by side.
 
 ### Finding your Frame ID
 
@@ -121,19 +162,22 @@ You still need to find your frame ID (the household identifier):
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `SKYLIGHT_EMAIL` | Option 1 | Your Skylight account email |
-| `SKYLIGHT_PASSWORD` | Option 1 | Your Skylight account password |
-| `SKYLIGHT_TOKEN` | Option 2 | Your API token (if not using email/password) |
-| `SKYLIGHT_AUTH_TYPE` | No | `bearer` (default) or `basic` (for manual token) |
+| `SKYLIGHT_ACCESS_TOKEN` | Option 1 | OAuth access token captured from the Skylight web app |
+| `SKYLIGHT_REFRESH_TOKEN` | Option 1 | OAuth refresh token captured from the Skylight web app |
+| `SKYLIGHT_DEVICE_FINGERPRINT` | Option 1 | Device fingerprint captured from the Skylight web app |
+| `SKYLIGHT_TOKEN` | Option 2 | Manual bearer token (alternative to OAuth) |
+| `SKYLIGHT_AUTH_TYPE` | No | `bearer` (default) or `basic` (Option 2 only) |
 | `SKYLIGHT_FRAME_ID` | Yes | Your household frame ID |
 | `SKYLIGHT_TIMEZONE` | No | Default timezone (default: `America/New_York`) |
+| `SKYLIGHT_STATE_FILE` | No | Override the persisted token state file path |
 
 ### Example .env file:
 
 ```env
-# Email/password auth (recommended)
-SKYLIGHT_EMAIL=your_email@example.com
-SKYLIGHT_PASSWORD=your_password
+# OAuth refresh-token mode (recommended; capture once from the web app)
+SKYLIGHT_ACCESS_TOKEN=your_access_token
+SKYLIGHT_REFRESH_TOKEN=your_refresh_token
+SKYLIGHT_DEVICE_FINGERPRINT=your_device_fingerprint
 SKYLIGHT_FRAME_ID=your_frame_id
 SKYLIGHT_TIMEZONE=America/New_York
 ```

--- a/scripts/show-state.mjs
+++ b/scripts/show-state.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+/**
+ * Print the location and contents of the Skylight token state file.
+ * Token values are shown as PREFIXES only (first 8 chars) — full secrets
+ * are never printed.
+ *
+ * Usage:  npm run build && node scripts/show-state.mjs
+ */
+
+import * as fs from "node:fs";
+import { getDefaultStatePath, readStateFile } from "../dist/api/token-store.js";
+
+function prefix(s) {
+  if (!s) return "<none>";
+  return `${s.slice(0, 8)}...`;
+}
+
+const filePath = getDefaultStatePath();
+console.log(`State file path: ${filePath}`);
+
+if (!fs.existsSync(filePath)) {
+  console.log("State file does not exist.");
+  console.log(
+    "  This is normal on first run — the server will write to this path the first time it refreshes a token."
+  );
+  console.log("  Until then, tokens are seeded from SKYLIGHT_ACCESS_TOKEN / SKYLIGHT_REFRESH_TOKEN.");
+  process.exit(0);
+}
+
+const stat = fs.statSync(filePath);
+console.log(`File size: ${stat.size} bytes`);
+console.log(`Modified:  ${stat.mtime.toISOString()}`);
+
+const stored = readStateFile(filePath);
+if (!stored) {
+  console.log("State file exists but is malformed.");
+  console.log("  The server will fall back to env vars on the next run.");
+  console.log("  To recover: delete this file, then provide fresh SKYLIGHT_ACCESS_TOKEN / SKYLIGHT_REFRESH_TOKEN values.");
+  process.exit(1);
+}
+
+console.log("");
+console.log(`Schema version: ${stored.schemaVersion}`);
+console.log(`Access token:   ${prefix(stored.accessToken)}`);
+console.log(`Refresh token:  ${prefix(stored.refreshToken)}`);
+console.log(
+  `Rotated at:     ${new Date(stored.rotatedAt).toISOString()} (${stored.rotatedAt} ms since epoch)`
+);

--- a/scripts/test-auth.mjs
+++ b/scripts/test-auth.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Smoke test for the Skylight OAuth refresh + persistence flow.
+ *
+ * On each run:
+ *   1. Loads the most recent refresh token (state file if present, else .env).
+ *   2. Refreshes via /oauth/token.
+ *   3. Persists the rotated tokens to the state file atomically.
+ *   4. Calls GET /api/user with the refreshed access token.
+ *   5. Re-reads the state file and asserts it contains the rotated tokens.
+ *
+ * Re-running this script without re-seeding .env exercises the persistence
+ * path: the second run reads tokens written by the first run.
+ *
+ * Token values are printed as PREFIXES only (first 8 chars) — full secrets
+ * never land on stdout.
+ *
+ * Usage:  npm run build && node scripts/test-auth.mjs
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { refreshAccessToken } from "../dist/api/auth.js";
+import { BROWSER_HEADERS } from "../dist/api/headers.js";
+import {
+  getDefaultStatePath,
+  readStateFile,
+  writeStateFileAtomic,
+} from "../dist/api/token-store.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const BASE_URL = "https://app.ourskylight.com";
+
+function loadDotEnv() {
+  const envPath = path.join(PROJECT_ROOT, ".env");
+  if (!fs.existsSync(envPath)) {
+    throw new Error(`.env file not found at ${envPath}`);
+  }
+  const content = fs.readFileSync(envPath, "utf8");
+  const result = {};
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    let value = line.slice(eq + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    result[key] = value;
+  }
+  return result;
+}
+
+function prefix(s) {
+  if (!s) return "<none>";
+  return `${s.slice(0, 8)}...`;
+}
+
+async function main() {
+  console.log("=== Skylight OAuth refresh + persistence smoke test ===");
+
+  const env = loadDotEnv();
+  const fingerprint = env.SKYLIGHT_DEVICE_FINGERPRINT;
+  if (!fingerprint) {
+    console.error("FAIL: .env is missing SKYLIGHT_DEVICE_FINGERPRINT");
+    process.exit(1);
+  }
+
+  const statePath = getDefaultStatePath();
+  console.log(`State file path: ${statePath}`);
+
+  const stored = readStateFile(statePath);
+  let activeRefreshToken;
+  let source;
+  if (stored) {
+    activeRefreshToken = stored.refreshToken;
+    source = `state file (rotated ${new Date(stored.rotatedAt).toISOString()})`;
+  } else {
+    activeRefreshToken = env.SKYLIGHT_REFRESH_TOKEN;
+    source = ".env (no state file present yet)";
+    if (!activeRefreshToken) {
+      console.error("FAIL: no state file present and .env is missing SKYLIGHT_REFRESH_TOKEN");
+      process.exit(1);
+    }
+  }
+
+  console.log(`Token source: ${source}`);
+  console.log(`Current refresh_token: ${prefix(activeRefreshToken)}`);
+  console.log(`device_fingerprint:    ${prefix(fingerprint)}`);
+
+  console.log("\nStep 1: POST /oauth/token (grant_type=refresh_token)");
+  let refreshed;
+  try {
+    refreshed = await refreshAccessToken(activeRefreshToken, fingerprint);
+  } catch (err) {
+    console.error(`FAIL: refresh threw: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+  console.log(`  PASS new access_token:  ${prefix(refreshed.accessToken)}`);
+  console.log(`  PASS new refresh_token: ${prefix(refreshed.refreshToken)}`);
+  console.log(
+    `  expires_in=${refreshed.expiresInSeconds}s, scope=${refreshed.scope}, token_type=${refreshed.tokenType}`
+  );
+
+  if (refreshed.refreshToken === activeRefreshToken) {
+    console.warn("  WARN: new refresh_token is identical to old (no rotation observed)");
+  }
+
+  console.log("\nStep 2: persist rotated tokens to state file (atomic write)");
+  try {
+    writeStateFileAtomic(statePath, {
+      schemaVersion: 1,
+      accessToken: refreshed.accessToken,
+      refreshToken: refreshed.refreshToken,
+      rotatedAt: Date.now(),
+    });
+    console.log(`  PASS wrote ${statePath}`);
+  } catch (err) {
+    console.error(`FAIL: writeStateFileAtomic threw: ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  console.log("\nStep 3: GET /api/user with refreshed access token");
+  const userResp = await fetch(`${BASE_URL}/api/user`, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${refreshed.accessToken}`,
+      Accept: "application/json",
+      ...BROWSER_HEADERS,
+    },
+  });
+  console.log(`  status=${userResp.status}`);
+  if (!userResp.ok) {
+    const errBody = await userResp.text();
+    console.error(`FAIL: /api/user returned ${userResp.status}: ${errBody.slice(0, 300)}`);
+    process.exit(1);
+  }
+  const userJson = await userResp.json();
+  const sub = userJson?.data?.attributes?.subscription_status;
+  const id = userJson?.data?.id;
+  console.log(`  PASS user id=${id ?? "<missing>"}, subscription_status=${sub ?? "<missing>"}`);
+
+  console.log("\nStep 4: re-read state file and verify it contains the rotated tokens");
+  const reread = readStateFile(statePath);
+  if (!reread) {
+    console.error(`FAIL: state file at ${statePath} could not be read after write`);
+    process.exit(1);
+  }
+  if (reread.accessToken !== refreshed.accessToken) {
+    console.error(
+      `FAIL: state file accessToken (${prefix(reread.accessToken)}) does not match refreshed (${prefix(refreshed.accessToken)})`
+    );
+    process.exit(1);
+  }
+  if (reread.refreshToken !== refreshed.refreshToken) {
+    console.error(
+      `FAIL: state file refreshToken (${prefix(reread.refreshToken)}) does not match refreshed (${prefix(refreshed.refreshToken)})`
+    );
+    process.exit(1);
+  }
+  console.log(`  PASS state file contains rotated tokens`);
+  console.log(`  state.accessToken:  ${prefix(reread.accessToken)}`);
+  console.log(`  state.refreshToken: ${prefix(reread.refreshToken)}`);
+  console.log(`  state.rotatedAt:    ${new Date(reread.rotatedAt).toISOString()}`);
+
+  console.log("\n=== ALL CHECKS PASSED ===");
+}
+
+main().catch((err) => {
+  console.error("UNEXPECTED FAILURE:", err);
+  process.exit(1);
+});

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,95 +1,116 @@
 /**
- * Skylight Authentication
- * Handles login via email/password to obtain API token
+ * Skylight OAuth 2.0 token refresh.
+ *
+ * Skylight migrated from a custom POST /api/sessions login (email/password)
+ * to OAuth 2.0 with /oauth/token. We never run grant_type=authorization_code
+ * from this codebase — the user captures access+refresh tokens once via the
+ * web app and supplies them via env. We refresh using grant_type=refresh_token
+ * whenever the access token expires (signaled by a 401).
  */
 
-const BASE_URL = "https://app.ourskylight.com";
+import { BROWSER_HEADERS } from "./headers.js";
 
-export interface LoginResponse {
-  data: {
-    id: string;
-    type: "authenticated_user";
-    attributes: {
-      email: string;
-      token: string;
-      subscription_status: string;
-    };
-  };
-  meta?: {
-    password_reset?: boolean;
-  };
+const BASE_URL = "https://app.ourskylight.com";
+const OAUTH_TOKEN_PATH = "/oauth/token";
+
+const OAUTH_CLIENT_ID = "skylight-mobile";
+const OAUTH_SCOPE = "everything";
+
+export interface OAuthTokenResponse {
+  accessToken: string;
+  refreshToken: string;
+  tokenType: string;
+  scope: string;
+  expiresInSeconds: number;
+  createdAt: number;
 }
 
-export interface AuthResult {
-  userId: string;
-  email: string;
-  token: string;
-  subscriptionStatus: string;
+interface RawOAuthTokenResponse {
+  access_token: string;
+  refresh_token: string;
+  token_type: string;
+  scope: string;
+  expires_in: number;
+  created_at: number;
+}
+
+export class TokenRefreshError extends Error {
+  constructor(
+    message: string,
+    public statusCode?: number,
+    public responseBody?: string
+  ) {
+    super(message);
+    this.name = "TokenRefreshError";
+  }
 }
 
 /**
- * Login to Skylight with email and password
- * Returns the authentication token and user info
+ * Refresh an access token using the OAuth 2.0 refresh_token grant.
+ * Skylight rotates BOTH access_token and refresh_token in the response,
+ * so callers must persist the new refresh_token if they want continuity
+ * across process restarts.
  */
-export async function login(email: string, password: string): Promise<AuthResult> {
-  console.error(`[auth] Attempting login for ${email}...`);
+export async function refreshAccessToken(
+  refreshToken: string,
+  deviceFingerprint: string
+): Promise<OAuthTokenResponse> {
+  console.error("[auth] Refreshing OAuth access token...");
 
-  const response = await fetch(`${BASE_URL}/api/sessions`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json",
-    },
-    body: JSON.stringify({ email, password }),
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    client_id: OAUTH_CLIENT_ID,
+    scope: OAUTH_SCOPE,
+    skylight_api_client_device_fingerprint: deviceFingerprint,
+    skylight_api_client_device_platform: "web",
+    skylight_api_client_device_name: "unknown",
+    skylight_api_client_device_os_version: "10",
+    skylight_api_client_device_app_version: "unknown",
+    skylight_api_client_device_hardware: "3",
+    source: "js-mobile",
   });
 
-  console.error(`[auth] Login response status: ${response.status}`);
+  const response = await fetch(`${BASE_URL}${OAUTH_TOKEN_PATH}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+      ...BROWSER_HEADERS,
+    },
+    body: body.toString(),
+  });
+
+  console.error(`[auth] Refresh response status: ${response.status}`);
 
   if (!response.ok) {
     let errorBody = "";
     try {
       errorBody = await response.text();
-      console.error(`[auth] Login error response: ${errorBody}`);
     } catch {
       // ignore
     }
-
-    if (response.status === 401) {
-      throw new Error(`Invalid email or password. Please check your SKYLIGHT_EMAIL and SKYLIGHT_PASSWORD environment variables.`);
-    }
-    throw new Error(`Login failed: HTTP ${response.status}${errorBody ? ` - ${errorBody}` : ""}`);
+    throw new TokenRefreshError(
+      `OAuth token refresh failed (HTTP ${response.status}). Your refresh token may be expired or revoked. ` +
+        `Re-capture SKYLIGHT_ACCESS_TOKEN and SKYLIGHT_REFRESH_TOKEN from the Skylight web app and update your .env.` +
+        (errorBody ? ` Server response: ${errorBody.slice(0, 200)}` : ""),
+      response.status,
+      errorBody
+    );
   }
 
-  const data = (await response.json()) as LoginResponse;
-
-  console.error(`[auth] Login successful, token prefix: ${data.data.attributes.token.substring(0, 10)}...`);
+  const raw = (await response.json()) as RawOAuthTokenResponse;
+  console.error(
+    `[auth] Refresh successful. new access_token=${raw.access_token.substring(0, 8)}..., ` +
+      `new refresh_token=${raw.refresh_token.substring(0, 8)}...`
+  );
 
   return {
-    userId: data.data.id,
-    email: data.data.attributes.email,
-    token: data.data.attributes.token,
-    subscriptionStatus: data.data.attributes.subscription_status,
+    accessToken: raw.access_token,
+    refreshToken: raw.refresh_token,
+    tokenType: raw.token_type,
+    scope: raw.scope,
+    expiresInSeconds: raw.expires_in,
+    createdAt: raw.created_at,
   };
-}
-
-// Cache for auth result
-let cachedAuth: AuthResult | null = null;
-
-/**
- * Get cached auth result or login if needed
- */
-export async function getAuth(email: string, password: string): Promise<AuthResult> {
-  if (cachedAuth) {
-    return cachedAuth;
-  }
-
-  cachedAuth = await login(email, password);
-  return cachedAuth;
-}
-
-/**
- * Clear cached auth (for re-login)
- */
-export function clearAuthCache(): void {
-  cachedAuth = null;
 }

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,11 @@
-import { getConfig, usesEmailAuth, type Config } from "../config.js";
-import { login } from "./auth.js";
+import { getConfig, usesOAuthRefresh, type Config } from "../config.js";
+import { refreshAccessToken, TokenRefreshError } from "./auth.js";
+import { BROWSER_HEADERS } from "./headers.js";
+import {
+  getDefaultStatePath,
+  readStateFile,
+  writeStateFileAtomic,
+} from "./token-store.js";
 import {
   AuthenticationError,
   NotFoundError,
@@ -9,9 +15,6 @@ import {
 
 const BASE_URL = "https://app.ourskylight.com";
 
-/**
- * Skylight subscription status types
- */
 export type SubscriptionStatus = "plus" | "free" | "trial" | null;
 
 export interface RequestOptions {
@@ -20,97 +23,107 @@ export interface RequestOptions {
   body?: unknown;
 }
 
+interface UserResponse {
+  data?: {
+    id?: string;
+    attributes?: {
+      subscription_status?: string;
+    };
+  };
+}
+
 /**
- * Skylight API Client
- * Handles authentication and HTTP requests to the Skylight API
+ * Skylight API client. Handles OAuth Bearer auth with automatic
+ * refresh-on-401 + single retry, or static manual-token mode.
  */
 export class SkylightClient {
   private config: Config;
-  private resolvedToken: string | null = null;
-  private resolvedUserId: string | null = null;
-  private loginPromise: Promise<{ token: string; userId: string }> | null = null;
+  private statePath: string;
+  private accessToken: string;
+  private refreshToken: string | null;
+  private refreshPromise: Promise<void> | null = null;
   private subscriptionStatus: SubscriptionStatus = null;
 
-  constructor(config?: Config) {
+  constructor(config?: Config, statePath?: string) {
     this.config = config ?? getConfig();
-  }
+    this.statePath = statePath ?? getDefaultStatePath();
 
-  /**
-   * Get the authentication credentials
-   * If using email/password auth, will login first
-   */
-  private async getCredentials(): Promise<{ token: string; userId: string | null }> {
-    // If we already have a resolved token, use it
-    if (this.resolvedToken) {
-      return { token: this.resolvedToken, userId: this.resolvedUserId };
-    }
-
-    // If using token-based auth, use the configured token
-    if (!usesEmailAuth(this.config)) {
-      return { token: this.config.token!, userId: null };
-    }
-
-    // If already logging in, wait for that to complete
-    if (this.loginPromise) {
-      const result = await this.loginPromise;
-      return { token: result.token, userId: result.userId };
-    }
-
-    // Login with email/password
-    this.loginPromise = this.performLogin();
-    try {
-      const result = await this.loginPromise;
-      this.resolvedToken = result.token;
-      this.resolvedUserId = result.userId;
-      return result;
-    } finally {
-      this.loginPromise = null;
+    if (usesOAuthRefresh(this.config)) {
+      // Prefer persisted (rotated) tokens over env-var seed values.
+      const stored = readStateFile(this.statePath);
+      if (stored) {
+        console.error(
+          `[client] Using persisted tokens from ${this.statePath} (rotated ${new Date(stored.rotatedAt).toISOString()})`
+        );
+        this.accessToken = stored.accessToken;
+        this.refreshToken = stored.refreshToken;
+      } else {
+        console.error("[client] No valid persisted state; seeding tokens from env vars.");
+        this.accessToken = this.config.accessToken!;
+        this.refreshToken = this.config.refreshToken!;
+      }
+    } else {
+      this.accessToken = this.config.token!;
+      this.refreshToken = null;
     }
   }
 
-  /**
-   * Perform login and return token and userId
-   */
-  private async performLogin(): Promise<{ token: string; userId: string }> {
-    const { email, password } = this.config;
-    if (!email || !password) {
-      throw new AuthenticationError("Email and password are required for login");
+  private getAuthHeader(): string {
+    if (usesOAuthRefresh(this.config)) {
+      return `Bearer ${this.accessToken}`;
     }
-
-    console.error("Logging in to Skylight...");
-    const result = await login(email, password);
-    this.subscriptionStatus = result.subscriptionStatus as SubscriptionStatus;
-    console.error(`Logged in as ${result.email} (${result.subscriptionStatus})`);
-    return { token: result.token, userId: result.userId };
-  }
-
-  /**
-   * Build the Authorization header
-   * For email/password auth: Basic base64(userId:token)
-   * For manual token auth: Bearer or Basic based on config
-   */
-  private async getAuthHeader(): Promise<string> {
-    const { token, userId } = await this.getCredentials();
-
-    // If using email/password auth, use Basic auth with userId:token
-    if (usesEmailAuth(this.config) && userId) {
-      const credentials = Buffer.from(`${userId}:${token}`).toString("base64");
-      return `Basic ${credentials}`;
-    }
-
-    // For manual token config, respect the authType setting
     if (this.config.authType === "basic") {
-      return `Basic ${token}`;
+      return `Basic ${this.accessToken}`;
     }
-    return `Bearer ${token}`;
+    return `Bearer ${this.accessToken}`;
   }
 
-  /**
-   * Build URL with query parameters
-   */
-  private buildUrl(endpoint: string, params?: Record<string, string | boolean | number | undefined>): string {
-    const url = new URL(endpoint, BASE_URL);
+  private async performRefresh(): Promise<void> {
+    if (!usesOAuthRefresh(this.config) || !this.refreshToken) {
+      throw new AuthenticationError(
+        "API request returned 401 and no refresh token is available. " +
+          "If using SKYLIGHT_TOKEN, capture a fresh token. Otherwise set " +
+          "SKYLIGHT_ACCESS_TOKEN / SKYLIGHT_REFRESH_TOKEN / SKYLIGHT_DEVICE_FINGERPRINT for automatic refresh."
+      );
+    }
 
+    try {
+      const result = await refreshAccessToken(this.refreshToken, this.config.deviceFingerprint!);
+      this.accessToken = result.accessToken;
+      this.refreshToken = result.refreshToken;
+
+      // Persist the rotated pair before releasing the refresh lock so any
+      // concurrent waiters that retry next will see a consistent on-disk state.
+      try {
+        writeStateFileAtomic(this.statePath, {
+          schemaVersion: 1,
+          accessToken: this.accessToken,
+          refreshToken: this.refreshToken,
+          rotatedAt: Date.now(),
+        });
+        console.error(`[client] Persisted rotated tokens to ${this.statePath}`);
+      } catch (writeErr) {
+        // Don't fail the refresh — in-memory tokens are valid for this process.
+        // Cold-start recovery will fall back to env vars (which may be stale).
+        console.error(
+          `[client] Failed to persist rotated tokens to ${this.statePath}: ${
+            writeErr instanceof Error ? writeErr.message : String(writeErr)
+          }. Subsequent process starts may need fresh env-var tokens.`
+        );
+      }
+    } catch (err) {
+      if (err instanceof TokenRefreshError) {
+        throw new AuthenticationError(err.message);
+      }
+      throw err;
+    }
+  }
+
+  private buildUrl(
+    endpoint: string,
+    params?: Record<string, string | boolean | number | undefined>
+  ): string {
+    const url = new URL(endpoint, BASE_URL);
     if (params) {
       for (const [key, value] of Object.entries(params)) {
         if (value !== undefined) {
@@ -118,29 +131,18 @@ export class SkylightClient {
         }
       }
     }
-
     return url.toString();
   }
 
-  /**
-   * Handle API response errors
-   */
   private async handleResponseError(response: Response, url: string): Promise<never> {
     const status = response.status;
 
     if (status === 401) {
-      // Clear cached credentials on auth failure
-      this.resolvedToken = null;
-      this.resolvedUserId = null;
       console.error(`[client] 401 Unauthorized for ${url}`);
-
-      if (usesEmailAuth(this.config)) {
-        throw new AuthenticationError(
-          "API request returned 401. This may indicate your frame ID is incorrect or doesn't belong to this account. " +
-            "Please verify your SKYLIGHT_FRAME_ID environment variable."
-        );
-      }
-      throw new AuthenticationError();
+      throw new AuthenticationError(
+        "API request returned 401 even after token refresh. Your refresh token may be expired/revoked, " +
+          "or your SKYLIGHT_FRAME_ID may not belong to this account."
+      );
     }
 
     if (status === 404) {
@@ -152,7 +154,6 @@ export class SkylightClient {
       throw new RateLimitError(retryAfter ? parseInt(retryAfter, 10) : undefined);
     }
 
-    // Try to get error details from response
     let errorMessage = `HTTP ${status}`;
     try {
       const errorBody = await response.text();
@@ -160,27 +161,24 @@ export class SkylightClient {
         errorMessage += `: ${errorBody.slice(0, 200)}`;
       }
     } catch {
-      // Ignore parse errors
+      // ignore
     }
 
     throw new SkylightError(errorMessage, "HTTP_ERROR", status, status >= 500);
   }
 
-  /**
-   * Make an authenticated request to the Skylight API
-   */
   async request<T>(endpoint: string, options: RequestOptions = {}, isRetry = false): Promise<T> {
     const { method = "GET", params, body } = options;
 
-    // Replace {frameId} placeholder with actual frame ID
     const resolvedEndpoint = endpoint.replace("{frameId}", this.config.frameId);
     const url = this.buildUrl(resolvedEndpoint, params);
 
     console.error(`[client] ${method} ${url}`);
 
     const headers: Record<string, string> = {
-      Authorization: await this.getAuthHeader(),
+      Authorization: this.getAuthHeader(),
       Accept: "application/json",
+      ...BROWSER_HEADERS,
     };
 
     if (body) {
@@ -196,17 +194,20 @@ export class SkylightClient {
     console.error(`[client] Response: ${response.status}`);
 
     if (!response.ok) {
-      // For email/password auth, try re-login once on 401
-      if (response.status === 401 && usesEmailAuth(this.config) && !isRetry) {
-        console.error("[client] Got 401, attempting re-login...");
-        this.resolvedToken = null;
-        this.resolvedUserId = null;
+      if (response.status === 401 && usesOAuthRefresh(this.config) && !isRetry) {
+        console.error("[client] Got 401, attempting OAuth token refresh...");
+        // Coalesce concurrent 401s onto a single in-flight refresh.
+        if (!this.refreshPromise) {
+          this.refreshPromise = this.performRefresh().finally(() => {
+            this.refreshPromise = null;
+          });
+        }
+        await this.refreshPromise;
         return this.request<T>(endpoint, options, true);
       }
       await this.handleResponseError(response, url);
     }
 
-    // Handle 304 Not Modified
     if (response.status === 304) {
       return {} as T;
     }
@@ -214,57 +215,61 @@ export class SkylightClient {
     return response.json() as Promise<T>;
   }
 
-  /**
-   * GET request helper
-   */
-  async get<T>(endpoint: string, params?: Record<string, string | boolean | number | undefined>): Promise<T> {
+  async get<T>(
+    endpoint: string,
+    params?: Record<string, string | boolean | number | undefined>
+  ): Promise<T> {
     return this.request<T>(endpoint, { method: "GET", params });
   }
 
-  /**
-   * POST request helper
-   */
   async post<T>(endpoint: string, body: unknown): Promise<T> {
     return this.request<T>(endpoint, { method: "POST", body });
   }
 
-  /**
-   * Get the frame ID from config
-   */
   get frameId(): string {
     return this.config.frameId;
   }
 
-  /**
-   * Get the timezone from config
-   */
   get timezone(): string {
     return this.config.timezone;
   }
 
-  /**
-   * Check if user has Plus subscription
-   */
   hasPlus(): boolean {
     return this.subscriptionStatus === "plus";
   }
 
-  /**
-   * Get the subscription status
-   */
   getSubscriptionStatus(): SubscriptionStatus {
     return this.subscriptionStatus;
   }
 
   /**
-   * Initialize the client (triggers login if using email/password auth)
+   * Snapshot of the currently-active OAuth tokens (useful after a refresh
+   * has rotated them, so callers can persist the new refresh_token).
+   */
+  getTokens(): { accessToken: string; refreshToken: string | null } {
+    return { accessToken: this.accessToken, refreshToken: this.refreshToken };
+  }
+
+  /**
+   * Initialize the client. Calls GET /api/user to determine subscription
+   * status — also serves as a connectivity / token-validity check, since a
+   * stale access_token will trigger the standard refresh-on-401 path here.
    */
   async initialize(): Promise<void> {
-    await this.getCredentials();
+    const user = await this.get<UserResponse>("/api/user");
+    const raw = user?.data?.attributes?.subscription_status;
+    if (raw === "plus" || raw === "free" || raw === "trial") {
+      this.subscriptionStatus = raw;
+    } else {
+      console.error(
+        `[client] /api/user returned unrecognized subscription_status=${JSON.stringify(raw)}; defaulting to 'free'.`
+      );
+      this.subscriptionStatus = "free";
+    }
+    console.error(`[client] Subscription status: ${this.subscriptionStatus}`);
   }
 }
 
-// Singleton instance
 let clientInstance: SkylightClient | null = null;
 
 export function getClient(): SkylightClient {
@@ -275,8 +280,8 @@ export function getClient(): SkylightClient {
 }
 
 /**
- * Initialize the client singleton and return it
- * This triggers login if using email/password auth
+ * Initialize the client singleton (fetches /api/user, refreshing the token
+ * first if it has already expired) and return it.
  */
 export async function initializeClient(): Promise<SkylightClient> {
   const client = getClient();

--- a/src/api/headers.ts
+++ b/src/api/headers.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared outbound headers for Skylight API requests.
+ *
+ * Skylight's API gates on both a date-based version header and on
+ * web-client-shaped Origin/Referer/User-Agent. Requests missing these
+ * are rejected with 401 "This version of Skylight is no longer supported".
+ * Applied to the OAuth refresh call (auth.ts) and authenticated API calls (client.ts).
+ */
+
+export const SKYLIGHT_API_VERSION = "2026-04-15";
+
+export const BROWSER_HEADERS: Record<string, string> = {
+  "skylight-api-version": SKYLIGHT_API_VERSION,
+  "User-Agent":
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36",
+  Origin: "https://ourskylight.com",
+  Referer: "https://ourskylight.com/",
+};

--- a/src/api/token-store.ts
+++ b/src/api/token-store.ts
@@ -1,0 +1,136 @@
+/**
+ * Persistent storage for OAuth tokens across process restarts.
+ *
+ * Skylight rotates refresh tokens on every refresh — the old refresh_token is
+ * invalidated the moment a new one is issued. So we cannot rely on the .env
+ * value beyond the first successful refresh; subsequent process starts must
+ * read the rotated tokens from disk.
+ *
+ * State file lives in the user data directory:
+ *   Windows: %APPDATA%\skylight-mcp\state.json
+ *   macOS:   ~/Library/Application Support/skylight-mcp/state.json
+ *   Linux:   $XDG_DATA_HOME/skylight-mcp/state.json (default ~/.local/share/...)
+ *
+ * The path can be overridden via the SKYLIGHT_STATE_FILE env var (used by tests
+ * and by ops tooling that wants to inspect a specific file).
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+export interface StoredTokens {
+  schemaVersion: 1;
+  accessToken: string;
+  refreshToken: string;
+  rotatedAt: number;
+}
+
+const APP_DIR_NAME = "skylight-mcp";
+const STATE_FILE_NAME = "state.json";
+
+/**
+ * Resolve the platform-appropriate state file path.
+ * Honors SKYLIGHT_STATE_FILE env var override (tests, debugging).
+ */
+export function getDefaultStatePath(): string {
+  const override = process.env.SKYLIGHT_STATE_FILE;
+  if (override && override.length > 0) {
+    return override;
+  }
+
+  const home = os.homedir();
+  let baseDir: string;
+
+  if (process.platform === "win32") {
+    baseDir = process.env.APPDATA || path.join(home, "AppData", "Roaming");
+  } else if (process.platform === "darwin") {
+    baseDir = path.join(home, "Library", "Application Support");
+  } else {
+    baseDir = process.env.XDG_DATA_HOME || path.join(home, ".local", "share");
+  }
+
+  return path.join(baseDir, APP_DIR_NAME, STATE_FILE_NAME);
+}
+
+/**
+ * Read tokens from the state file.
+ * Returns null when the file is missing, unreadable, malformed, or schema-incompatible.
+ * Callers fall back to env-var seed values.
+ */
+export function readStateFile(filePath: string): StoredTokens | null {
+  if (!fs.existsSync(filePath)) {
+    return null;
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf8");
+  } catch (err) {
+    console.error(
+      `[token-store] Could not read state file at ${filePath}: ${(err as Error).message}. Falling back to env vars.`
+    );
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    console.error(
+      `[token-store] State file at ${filePath} is not valid JSON: ${(err as Error).message}. Falling back to env vars.`
+    );
+    return null;
+  }
+
+  if (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    "accessToken" in parsed &&
+    "refreshToken" in parsed
+  ) {
+    const obj = parsed as Record<string, unknown>;
+    if (
+      typeof obj.accessToken === "string" &&
+      typeof obj.refreshToken === "string" &&
+      obj.accessToken.length > 0 &&
+      obj.refreshToken.length > 0
+    ) {
+      return {
+        schemaVersion: 1,
+        accessToken: obj.accessToken,
+        refreshToken: obj.refreshToken,
+        rotatedAt: typeof obj.rotatedAt === "number" ? obj.rotatedAt : Date.now(),
+      };
+    }
+  }
+
+  console.error(
+    `[token-store] State file at ${filePath} is missing required fields (accessToken, refreshToken). Falling back to env vars.`
+  );
+  return null;
+}
+
+/**
+ * Write tokens to the state file atomically: write to a temp file, fsync,
+ * then rename onto the final path. Prevents half-written files if the process
+ * is killed mid-write. Sets file mode 0600 on POSIX (no-op on Windows, which
+ * uses ACLs rather than POSIX bits).
+ */
+export function writeStateFileAtomic(filePath: string, tokens: StoredTokens): void {
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const tmpPath = `${filePath}.tmp.${process.pid}.${Date.now()}`;
+  const data = JSON.stringify(tokens, null, 2);
+
+  const fd = fs.openSync(tmpPath, "w", 0o600);
+  try {
+    fs.writeFileSync(fd, data);
+    fs.fsyncSync(fd);
+  } finally {
+    fs.closeSync(fd);
+  }
+
+  fs.renameSync(tmpPath, filePath);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,15 +1,21 @@
 import { z } from "zod";
 
 // Config schema supports two auth methods:
-// 1. Email/password (preferred) - will login and get token automatically
-// 2. Token-based (legacy) - for manual token capture
+// 1. OAuth refresh — access_token + refresh_token + device_fingerprint (preferred,
+//    refreshes automatically when the access token expires)
+// 2. Manual bearer token — single SKYLIGHT_TOKEN (fallback; no refresh, expires
+//    when the captured token expires).
+//
+// Email/password auth (SKYLIGHT_EMAIL / SKYLIGHT_PASSWORD) is no longer supported
+// because Skylight removed the POST /api/sessions endpoint.
 const ConfigSchema = z
   .object({
-    // Email/password auth (preferred)
-    email: z.string().email().optional(),
-    password: z.string().min(1).optional(),
+    // OAuth refresh-token mode
+    accessToken: z.string().min(1).optional(),
+    refreshToken: z.string().min(1).optional(),
+    deviceFingerprint: z.string().min(1).optional(),
 
-    // Token-based auth (legacy)
+    // Manual bearer-token fallback
     token: z.string().min(1).optional(),
     authType: z.enum(["bearer", "basic"]).default("bearer"),
 
@@ -21,29 +27,32 @@ const ConfigSchema = z
   })
   .refine(
     (data) => {
-      // Must have either email+password OR token
-      const hasEmailAuth = data.email && data.password;
-      const hasTokenAuth = !!data.token;
-      return hasEmailAuth || hasTokenAuth;
+      const hasOAuth = !!(data.accessToken && data.refreshToken && data.deviceFingerprint);
+      const hasManualToken = !!data.token;
+      return hasOAuth || hasManualToken;
     },
     {
-      message: "Either SKYLIGHT_EMAIL and SKYLIGHT_PASSWORD, or SKYLIGHT_TOKEN must be provided",
+      message:
+        "Provide either (SKYLIGHT_ACCESS_TOKEN + SKYLIGHT_REFRESH_TOKEN + SKYLIGHT_DEVICE_FINGERPRINT) " +
+        "or SKYLIGHT_TOKEN. Email/password auth is no longer supported by the Skylight API.",
     }
   );
 
 export type Config = z.infer<typeof ConfigSchema>;
 
-export interface ResolvedConfig {
-  token: string;
-  frameId: string;
-  timezone: string;
-  authType: "bearer" | "basic";
-}
-
 export function loadConfig(): Config {
+  if (process.env.SKYLIGHT_EMAIL || process.env.SKYLIGHT_PASSWORD) {
+    console.error(
+      "[config] SKYLIGHT_EMAIL / SKYLIGHT_PASSWORD are set but no longer supported. " +
+        "Skylight migrated to OAuth 2.0; the old /api/sessions endpoint returns 401. " +
+        "Capture access_token / refresh_token / device_fingerprint from the Skylight web app and use those instead."
+    );
+  }
+
   const result = ConfigSchema.safeParse({
-    email: process.env.SKYLIGHT_EMAIL,
-    password: process.env.SKYLIGHT_PASSWORD,
+    accessToken: process.env.SKYLIGHT_ACCESS_TOKEN,
+    refreshToken: process.env.SKYLIGHT_REFRESH_TOKEN,
+    deviceFingerprint: process.env.SKYLIGHT_DEVICE_FINGERPRINT,
     token: process.env.SKYLIGHT_TOKEN,
     frameId: process.env.SKYLIGHT_FRAME_ID,
     authType: process.env.SKYLIGHT_AUTH_TYPE || "bearer",
@@ -59,12 +68,13 @@ Missing or invalid configuration:
 ${errors}
 
 Authentication (choose one):
-  Option 1 - Email/Password (recommended):
-    SKYLIGHT_EMAIL    - Your Skylight account email
-    SKYLIGHT_PASSWORD - Your Skylight account password
+  Option 1 - OAuth refresh-token mode (recommended):
+    SKYLIGHT_ACCESS_TOKEN       - Captured from the Skylight web app
+    SKYLIGHT_REFRESH_TOKEN      - Captured from the Skylight web app
+    SKYLIGHT_DEVICE_FINGERPRINT - Captured from the Skylight web app
 
-  Option 2 - Manual Token:
-    SKYLIGHT_TOKEN    - Your Skylight API token
+  Option 2 - Manual bearer token (no automatic refresh):
+    SKYLIGHT_TOKEN     - Captured access token
     SKYLIGHT_AUTH_TYPE - 'bearer' or 'basic' (default: bearer)
 
 Required:
@@ -73,10 +83,8 @@ Required:
 Optional:
   SKYLIGHT_TIMEZONE - Timezone for dates (default: America/New_York)
 
-To find your frame ID:
-1. Log in to the Skylight app
-2. Use a proxy tool to capture API traffic
-3. Look for the frame ID in URLs like /api/frames/{frameId}/chores
+Email/password auth (SKYLIGHT_EMAIL / SKYLIGHT_PASSWORD) is no longer supported.
+The Skylight API migrated to OAuth 2.0; the old /api/sessions endpoint returns 401.
 `);
     process.exit(1);
   }
@@ -94,8 +102,9 @@ export function getConfig(): Config {
 }
 
 /**
- * Check if config uses email/password auth
+ * Check whether config uses OAuth refresh-token mode.
+ * False means we're in manual-token fallback mode (no refresh available).
  */
-export function usesEmailAuth(config: Config): boolean {
-  return !!(config.email && config.password);
+export function usesOAuthRefresh(config: Config): boolean {
+  return !!(config.accessToken && config.refreshToken && config.deviceFingerprint);
 }


### PR DESCRIPTION
## Summary

Skylight migrated their API to OAuth 2.0 with hosted login; the package's email/password endpoint (`POST /api/sessions`) is gone. Every install of `@eaglebyte/skylight-mcp` currently returns 401 on first request. This PR replaces the dead auth path with the OAuth refresh-token grant, adds cross-platform token persistence to handle Skylight's strict refresh-token rotation, and updates the README's auth section to match.

## The problem

Users running this package today see their MCP client fail with the misleading message:

> Authentication Error: Invalid email or password. Please check your SKYLIGHT_EMAIL and SKYLIGHT_PASSWORD environment variables.

That message comes from the package's own 401 handler in the old `login()` path — but the credentials aren't actually wrong. What Skylight returns is:

```
HTTP 401
{ "error": "This version of Skylight is no longer supported." }
```

The 401 → "invalid credentials" translation in the existing code sends users on a wild goose chase resetting passwords and double-checking accounts. The real cause is that `POST /api/sessions` is gone; Skylight retired the endpoint upstream. No header tweak, version bump, or User-Agent shim recovers it — the route no longer exists.

## Investigation

HAR captures from `app.ourskylight.com` show the live web client uses OAuth 2.0 Authorization Code with hosted login (browser redirect to Skylight's login page, callback with `code`, exchanged at `POST /oauth/token`). The `client_id` is `skylight-mobile`. Refresh-token rotation is strict: the old `refresh_token` is invalidated the moment a new one is issued — confirmed empirically by re-running the smoke test against a just-used refresh token and getting `HTTP 400 invalid_grant`. That rotation behavior is the central reason in-memory token state is insufficient and persistence is required.

## What changed

**Auth flow rewritten to OAuth refresh-token grant.** Full body params reproduced from the HAR — `grant_type=refresh_token`, `refresh_token`, `client_id=skylight-mobile`, `scope=everything`, `skylight_api_client_device_fingerprint`, `skylight_api_client_device_platform=web`, plus six more device fields (`device_name`, `device_os_version`, `device_app_version`, `device_hardware`, `source`). Sent as `application/x-www-form-urlencoded` to `POST /oauth/token`.

**New `src/api/token-store.ts` for cross-platform state persistence.** Atomic writes via `tmp + fsync + rename` to prevent half-written files on crash. POSIX file mode `0o600` on the temp fd (no-op on Windows, which uses ACLs). State paths follow each platform's user data dir convention:

- Windows: `%APPDATA%\skylight-mcp\state.json`
- macOS: `~/Library/Application Support/skylight-mcp/state.json`
- Linux: `$XDG_DATA_HOME/skylight-mcp/state.json` (default `~/.local/share/skylight-mcp/state.json`)

Schema-versioned JSON so future migrations don't crash on old files. The `SKYLIGHT_STATE_FILE` env var overrides the default path (useful for tests and parallel configs).

**`src/api/client.ts` reads state file first.** On startup it prefers persisted (rotated) tokens over env-var seed values. Env vars are used only on the very first run or after the state file is deleted/corrupted. Malformed state files log a warning and fall through to env vars rather than crashing.

**401 → refresh → retry-once flow.** Authenticated requests that get a 401 trigger a single refresh and retry. Concurrent 401s coalesce onto the same in-flight refresh promise so we never fire two `POST /oauth/token` requests in parallel and clobber each other's tokens. Persistence happens inside the same critical section as the in-memory swap, so the on-disk state is sequenced with the in-memory state.

**Email/password code path deleted, not deprecated.** The endpoint is gone; soft-deprecation would just keep printing instructions for an auth method that physically can't work. The config validator emits a clear deprecation warning if `SKYLIGHT_EMAIL` / `SKYLIGHT_PASSWORD` are still set, then fails with a config error pointing at the new env vars.

**New env vars:** `SKYLIGHT_ACCESS_TOKEN`, `SKYLIGHT_REFRESH_TOKEN`, `SKYLIGHT_DEVICE_FINGERPRINT`. Existing `SKYLIGHT_TOKEN` manual-bearer path is retained as a fallback for users who prefer to manage tokens manually without auto-refresh.

**README authentication section rewritten** with the one-time DevTools capture procedure (Network tab → filter `oauth/token` → POST 200 → Response tab for tokens, Payload tab for fingerprint). Configuration table updated to reflect the new env vars; example `.env` updated; Quick Start `mcp.json` snippets updated so copy-pasted configs actually work.

**`scripts/show-state.mjs`** prints the state file path, mtime, and token prefixes (first 8 chars) for users debugging their setup. No full secrets ever land on stdout.

### Breaking change

Existing users on `SKYLIGHT_EMAIL` / `SKYLIGHT_PASSWORD` need to migrate. One-time browser DevTools capture, fully documented in the README. After that first capture, persistence is transparent — users won't need to think about tokens again unless they go inactive long enough for Skylight to invalidate the refresh token.

## Verification

- All 31 existing vitest tests pass (`npm test`).
- New smoke test (`scripts/test-auth.mjs`) verifies the full flow including persistence end-to-end. Ran twice consecutively without re-seeding `.env`: the first run reads `.env`, refreshes, persists; the second run reads the persisted (rotated) tokens and refreshes again. If persistence weren't working, run 2 would fail with the same `HTTP 400 invalid_grant` error that originally proved Skylight's rotation is strict — so a passing second run is a strong signal the persistence layer is sound.
- End-to-end tested against the live Skylight API: refresh succeeded with HTTP 200, `GET /api/user` returned 200 with `subscription_status=plus`, and the MCP server connects and serves tools (calendar, chores, lists, plus the Plus-only meals/rewards/photos) inside Claude Desktop without manual intervention across multiple cold starts.
- Build is clean (`tsc` with strict mode + `noUnusedLocals` + `noUnusedParameters`).

## Known limitations and follow-up ideas

- **Multi-process refresh-token races.** Two skylight-mcp processes refreshing simultaneously could race the state-file write — the loser's atomic rename overwrites the winner's, and the next cold start uses whichever wrote last. Unlikely in practice with a single Claude Desktop instance, but worth flagging. Standard mitigation would be file locking via `proper-lockfile` or similar; happy to add it as a follow-up if you'd rather not depend on the single-writer assumption.
- **Token capture is currently manual.** Reasonable next step: a CLI helper that walks the user through DevTools, or a headless-browser login flow that runs Authorization Code end-to-end on the user's behalf. Both are bigger projects than this PR; flagging for the roadmap.
- **Device fingerprint longevity.** The captured `skylight_api_client_device_fingerprint` is a UUID generated client-side and apparently tied to the browser session. Reusing it across sessions works in testing today, but whether Skylight ever invalidates fingerprints longer-term is unknown. Worth monitoring; if it becomes an issue, the fix is the same DevTools capture.

---

Thanks for reviewing. Happy to iterate on naming, structure, or scope — particularly if you'd prefer to land the auth fix and persistence layer as separate PRs, or if there's a different convention for state-file location you'd like me to match.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth 2.0 token refresh authentication with automatic token rotation and disk persistence.
  * Token state visibility via new CLI utility.

* **Breaking Changes**
  * Email and password authentication removed; OAuth refresh tokens or manual bearer tokens now required.
  * Configuration environment variables updated.

* **Documentation**
  * README updated with OAuth setup instructions and token persistence details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->